### PR TITLE
improve raw mode docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -387,20 +387,43 @@ echo -n baz | kubectl create secret generic mysecret --dry-run=client --from-fil
 
 Creating temporary Secret with the `kubectl` command, only to throw it away once piped to `kubeseal` can
 be a quite unfriendly user experience. We're working on an overhaul of the the CLI experience. In the meantime,
-we offer an alternative mode where kubeseal only cares about encrypting a value to stdout and it's your responsibility to put it inside a SealedSecret resource (not unlike any of the other k8s resources).
+we offer an alternative mode where kubeseal only cares about encrypting a value to stdout and it's your responsibility to put it inside a `SealedSecret` resource (not unlike any of the other k8s resources).
 
 It can also be useful as a building block for editor/IDE integrations.
 
 The downside is that you have to be careful to be consistent with the sealing scope, the namespace and the name.
-See [Scopes](#scopes):
+
+See [Scopes](#scopes)
+
+#### scrict scope (default)
 
 ```console
 $ echo -n foo | kubeseal --raw --from-file=/dev/stdin --namespace bar --name mysecret
 AgBChHUWLMx...
+```
+#### namespace-wide scope
+
+```console
 $ echo -n foo | kubeseal --raw --from-file=/dev/stdin --namespace bar --scope namespace-wide
 AgAbbFNkM54...
+```
+Include the `sealedsecrets.bitnami.com/namespace-wide` annotation in the `SealedSecret`
+```yaml
+metadata:
+  annotations:
+    sealedsecrets.bitnami.com/namespace-wide: "true"
+```
+#### cluster-wide scope
+
+```console
 $ echo -n foo | kubeseal --raw --from-file=/dev/stdin --scope cluster-wide
 AgAjLKpIYV+...
+```
+Include the `sealedsecrets.bitnami.com/cluster-wide` annotation in the `SealedSecret`
+```yaml
+metadata:
+  annotations:
+    sealedsecrets.bitnami.com/cluster-wide: "true"
 ```
 
 ## Secret Rotation

--- a/README.md
+++ b/README.md
@@ -397,14 +397,14 @@ See [Scopes](#scopes)
 
 #### strict scope (default)
 
-```console
+```bash
 $ echo -n foo | kubeseal --raw --from-file=/dev/stdin --namespace bar --name mysecret
 AgBChHUWLMx...
 ```
 
 #### namespace-wide scope
 
-```console
+```bash
 $ echo -n foo | kubeseal --raw --from-file=/dev/stdin --namespace bar --scope namespace-wide
 AgAbbFNkM54...
 ```
@@ -417,7 +417,7 @@ metadata:
 
 #### cluster-wide scope
 
-```console
+```bash
 $ echo -n foo | kubeseal --raw --from-file=/dev/stdin --scope cluster-wide
 AgAjLKpIYV+...
 ```

--- a/README.md
+++ b/README.md
@@ -401,6 +401,7 @@ See [Scopes](#scopes)
 $ echo -n foo | kubeseal --raw --from-file=/dev/stdin --namespace bar --name mysecret
 AgBChHUWLMx...
 ```
+
 #### namespace-wide scope
 
 ```console
@@ -413,6 +414,7 @@ metadata:
   annotations:
     sealedsecrets.bitnami.com/namespace-wide: "true"
 ```
+
 #### cluster-wide scope
 
 ```console

--- a/README.md
+++ b/README.md
@@ -395,7 +395,7 @@ The downside is that you have to be careful to be consistent with the sealing sc
 
 See [Scopes](#scopes)
 
-#### scrict scope (default)
+#### strict scope (default)
 
 ```console
 $ echo -n foo | kubeseal --raw --from-file=/dev/stdin --namespace bar --name mysecret

--- a/README.md
+++ b/README.md
@@ -395,16 +395,16 @@ The downside is that you have to be careful to be consistent with the sealing sc
 
 See [Scopes](#scopes)
 
-#### strict scope (default)
+`strict` scope (default):
 
-```bash
+```console
 $ echo -n foo | kubeseal --raw --from-file=/dev/stdin --namespace bar --name mysecret
 AgBChHUWLMx...
 ```
 
-#### namespace-wide scope
+`namespace-wide` scope:
 
-```bash
+```console
 $ echo -n foo | kubeseal --raw --from-file=/dev/stdin --namespace bar --scope namespace-wide
 AgAbbFNkM54...
 ```
@@ -415,9 +415,9 @@ metadata:
     sealedsecrets.bitnami.com/namespace-wide: "true"
 ```
 
-#### cluster-wide scope
+`cluster-wide` scope:
 
-```bash
+```console
 $ echo -n foo | kubeseal --raw --from-file=/dev/stdin --scope cluster-wide
 AgAjLKpIYV+...
 ```


### PR DESCRIPTION
Improves the raw mode docs to ensure users are aware that use of the namespace-wide or cluster-wide scope requires the SealedSecret, in which the encrypted value is placed, contain an annotation corresponding to the scope.